### PR TITLE
85-allow-other-prior-parameters

### DIFF
--- a/man/horseshoe.Rd
+++ b/man/horseshoe.Rd
@@ -12,6 +12,8 @@ horseshoe(
   data,
   resptype = c("survival", "binary"),
   status = NULL,
+  horseshoe_prior = brms::horseshoe(),
+  normal_prior = "normal(0, 5)",
   ...
 )
 }
@@ -37,6 +39,13 @@ or "binary".}
 
 \item{status}{(\code{string})\cr only for "survival" \code{resptype},
 the status variable name in survival data.}
+
+\item{horseshoe_prior}{(\code{string})\cr the shrinkage prior definition,
+typically constructed with \code{brms::horseshoe()}.}
+
+\item{normal_prior}{(\code{string})\cr the normal prior definition in Stan language
+\code{"normal(0, 5)"}.
+.}
 
 \item{...}{Additional arguments from the \code{brm} function.}
 }

--- a/tests/testthat/test-horseshoe.R
+++ b/tests/testthat/test-horseshoe.R
@@ -103,3 +103,65 @@ test_that("horseshoe outputs the right elements for binary", {
   class(expected) <- c("bonsaiforest", "horseshoe")
   expect_equal(result, expected)
 })
+
+test_that("horseshoe works with different horsehoe parameters", {
+  result_1_2 <- suppressWarnings(horseshoe(
+    "tt_pfs",
+    "arm",
+    c("x_1", "x_3"),
+    c("x_1", "x_2", "x_3"),
+    example_data,
+    "survival", "ev_pfs",
+    iter = 20,
+    warmup = 10,
+    chains = 1,
+    seed = 0,
+    control = list(adapt_delta = 0.95),
+    horseshoe_prior = brms::horseshoe(df = 2, scale_global = 2)
+  ))
+
+  expect_equal(
+    summary(result_1_2)$estimates$trt.estimate,
+    c(0.65416396929456, 0.600816938551847, 0.619122568326682, 0.622155095860528)
+  )
+
+  result_2_1 <- suppressWarnings(horseshoe(
+    "tt_pfs",
+    "arm",
+    c("x_1", "x_3"),
+    c("x_1", "x_2", "x_3"),
+    example_data,
+    "survival", "ev_pfs",
+    iter = 20,
+    warmup = 10,
+    chains = 1,
+    seed = 0,
+    control = list(adapt_delta = 0.95),
+    horseshoe_prior = brms::horseshoe(df = 2)
+  ))
+
+  expect_equal(
+    summary(result_2_1)$estimates$trt.estimate,
+    c(0.634816327624216, 0.647031888165315, 0.608360177875747, 0.626950253467059)
+  )
+
+  result_1_1 <- suppressWarnings(horseshoe(
+    "tt_pfs",
+    "arm",
+    c("x_1", "x_3"),
+    c("x_1", "x_2", "x_3"),
+    example_data,
+    "survival", "ev_pfs",
+    iter = 20,
+    warmup = 10,
+    chains = 1,
+    seed = 0,
+    control = list(adapt_delta = 0.95),
+    horseshoe_prior = brms::horseshoe(df = 1)
+  ))
+
+  expect_equal(
+    summary(result_1_1)$estimates$trt.estimate,
+    c(0.645449993316656, 0.603629055392864, 0.59286841204553, 0.651850986522326)
+  )
+})


### PR DESCRIPTION
Proof of concept for testing #85 

- Seems to work for different horseshoe specifications and also R2D2.
- Need to choose better parameter names  (eg `main_effect_prior`, `shrinkage_prior`?)
- What validation can we do on prior strings?